### PR TITLE
words that only include letters in allowed str

### DIFF
--- a/count-number-consistent-strings/README.md
+++ b/count-number-consistent-strings/README.md
@@ -1,0 +1,28 @@
+You are given a string allowed consisting of distinct characters and an array of strings words. A string is consistent if all characters in the string appear in the string allowed.
+
+Return the number of consistent strings in the array words.
+
+Example 1:
+
+Input: allowed = "ab", words = ["ad","bd","aaab","baa","badab"]
+Output: 2
+Explanation: Strings "aaab" and "baa" are consistent since they only contain characters 'a' and 'b'.
+Example 2:
+
+Input: allowed = "abc", words = ["a","b","c","ab","ac","bc","abc"]
+Output: 7
+Explanation: All strings are consistent.
+Example 3:
+
+Input: allowed = "cad", words = ["cc","acd","b","ba","bac","bad","ac","d"]
+Output: 4
+Explanation: Strings "cc", "acd", "ac", and "d" are consistent.
+ 
+
+Constraints:
+
+1 <= words.length <= 104
+1 <= allowed.length <= 26
+1 <= words[i].length <= 10
+The characters in allowed are distinct.
+words[i] and allowed contain only lowercase English letters.

--- a/count-number-consistent-strings/answer.js
+++ b/count-number-consistent-strings/answer.js
@@ -1,0 +1,18 @@
+const countConsistentStrings = (allowed, words) =>{
+  allowedArr = allowed.split('');
+  const match = [];
+  for (let index = 0; index < words.length; index++) {
+    for (let index1 = 0; index1 < words[index].length; index1++) {
+      if (index1 === words[index].length - 1 && allowedArr.includes(words[index][index1]))
+        match.push(words[index]);
+      else if (!allowedArr.includes(words[index][index1]))
+        break;
+    }
+  }
+  return match.length;
+};
+
+
+allowed = "cad";
+words = ["cc","acd","b","ba","bac","bad","ac","d"];
+countConsistentStrings(allowed, words);


### PR DESCRIPTION
input: allowed = "ab", words = ["ad","bd","aaab","baa","badab"]
output:
<img width="27" alt="Screen Shot 2020-12-17 at 5 59 16 PM" src="https://user-images.githubusercontent.com/37121177/102562323-1402d700-4094-11eb-9dd8-d16edd9a6585.png">

input: allowed = "abc", words = ["a","b","c","ab","ac","bc","abc"]
output:
<img width="29" alt="Screen Shot 2020-12-17 at 5 59 46 PM" src="https://user-images.githubusercontent.com/37121177/102562341-1a914e80-4094-11eb-9015-41c6fa47bdd7.png">


input: allowed = "cad", words = ["cc","acd","b","ba","bac","bad","ac","d"]
output:
<img width="30" alt="Screen Shot 2020-12-17 at 6 00 40 PM" src="https://user-images.githubusercontent.com/37121177/102562347-1ebd6c00-4094-11eb-9c63-adece3415887.png">
